### PR TITLE
Parse env variables

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -140,6 +140,10 @@ class LogParser:
     def parse_outputs(text):
         return re.match('Job\soutputs:\s+(\[.*\])', text, re.I)
 
+    @staticmethod
+    def parse_env_variables(text):
+        return re.match('Environment variables \(HF_LOG\):\s+(.*)', text, re.I)
+
 
 def save_log(log, dest_file):
     with open(dest_file, "a", encoding='utf-8') as f:
@@ -281,6 +285,12 @@ def parse_single_log(log, job_description_logger, sys_info_logger, metrics_logge
         for file_dict in file_dict_tuple:
             file_sizes_dict.update(file_dict)
         job_description_logger.log_map['outputs'] = extend_with_sizes(job_description_logger.log_map['outputs'], file_sizes_dict)
+        return
+
+    metric = LogParser.parse_env_variables(text)
+    if metric:
+        env_vars = eval(metric.group(1))
+        metrics_logger.append_log(new_log, 'env', env_vars)
         return
 
     return None


### PR DESCRIPTION
Recently job-executor started logging environmental variables: https://github.com/hyperflow-wms/hyperflow-job-executor/commit/8d2e5ee57a2041341e5b9072625f6731ccbee51f
This PR adds support for such logs.