### PR TITLE
Parse new job-executor handler finish format

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -110,6 +110,11 @@ class LogParser:
 
     @staticmethod
     def parse_handler_finished(text):
+        # New format
+        match = re.match('handler finished.*', text, re.I)
+        if match is not None:
+            return match
+        # Backward compatibility with old job-executor format
         return re.match('handler exiting.*', text, re.I)
 
     @staticmethod


### PR DESCRIPTION
Parser does not detect handler end with new job executor - log message was recently changed: https://github.com/hyperflow-wms/hyperflow-job-executor/commit/fd455fe90a1dac7a2559eeb76508c36646ed271c:
![image](https://user-images.githubusercontent.com/6506780/93374984-c9d14600-f857-11ea-8bcf-b644830929d0.png)
![image](https://user-images.githubusercontent.com/6506780/93375039-d6ee3500-f857-11ea-84cf-ce3a9e34a2b0.png)

